### PR TITLE
Avoid overlapping nodes in 2D graphs

### DIFF
--- a/ThreeXPlusOne/Code/Graph/ThreeDimensionalDirectedGraph.cs
+++ b/ThreeXPlusOne/Code/Graph/ThreeDimensionalDirectedGraph.cs
@@ -57,8 +57,6 @@ public class ThreeDimensionalDirectedGraph(IOptions<Settings> settings,
             PositionNode(node);
         }
 
-        AdjustNodesWithSamePosition(nodesToDraw);
-
         _consoleHelper.WriteDone();
     }
 

--- a/ThreeXPlusOne/Code/Graph/TwoDimensionalDirectedGraph.cs
+++ b/ThreeXPlusOne/Code/Graph/TwoDimensionalDirectedGraph.cs
@@ -53,8 +53,6 @@ public class TwoDimensionalDirectedGraph(IOptions<Settings> settings,
             PositionNode(node);
         }
 
-        AdjustNodesWithSamePosition(nodesToDraw);
-
         _consoleHelper.WriteDone();
     }
 
@@ -120,6 +118,18 @@ public class TwoDimensionalDirectedGraph(IOptions<Settings> settings,
 
                 node.Position = new SKPoint((float)rotatedPosition.x, (float)rotatedPosition.y);
             }
+
+            float minDistance = _settings.NodeRadius * 2;
+
+            while (NodeIsTooCloseToNeighbours(node, minDistance))
+            {
+                node.Position = new SKPoint((float)node.Position.X + (node.IsFirstChild
+                                                                        ? -_settings.NodeRadius * 2 - 40
+                                                                        : _settings.NodeRadius * 2 + 40),
+                                            (float)node.Position.Y);
+            }
+
+            AddNodeToGrid(node, minDistance);
 
             node.IsPositioned = true;
             _nodesPositioned += 1;

--- a/ThreeXPlusOne/Config/Settings.cs
+++ b/ThreeXPlusOne/Config/Settings.cs
@@ -50,7 +50,7 @@ public class Settings
     /// <summary>
     /// The radius of the node
     /// </summary>
-    public float NodeRadius { get; set; } = 40;
+    public float NodeRadius { get; set; } = 50;
 
     /// <summary>
     /// Whether or not to distort nodes into various shapes and sizes
@@ -60,7 +60,7 @@ public class Settings
     /// <summary>
     /// The max amount in pixels by which to distort the node's radius
     /// </summary>
-    public int RadiusDistortion { get; set; } = 30;
+    public int RadiusDistortion { get; set; } = 25;
 
     /// <summary>
     /// The amount of x-axis space in pixels by which to separate nodes
@@ -75,7 +75,7 @@ public class Settings
     /// <summary>
     /// For pseudo-3D graphs, the distance from the viewer (to create perspective)
     /// </summary>
-    public float DistanceFromViewer { get; set; } = 200;
+    public float DistanceFromViewer { get; set; } = 300;
 
     /// <summary>
     /// The number of dimensions to render in the graph


### PR DESCRIPTION
- For 2D graphs
  - Add nodes to a grid dictionary when positioned
  - As new nodes are positioned, check grid to see if a node already populates that cell space in the grid
  - If the new node would overlap an existing node, adjust the new node's coordinates
- Change some default settings values