### PR TITLE
Fix hash naming issue

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -5,9 +5,9 @@ name: .NET
 
 on:
   push:
-    branches: [ "main", "feature/*" ]
+    branches: [ "main", "feature/*, bugfix/*" ]
   pull_request:
-    branches: [ "main", "feature/*" ]
+    branches: [ "main", "feature/*, bugfix/*" ]
 
 jobs:
   build:

--- a/ThreeXPlusOne/Config/Settings.cs
+++ b/ThreeXPlusOne/Config/Settings.cs
@@ -234,7 +234,10 @@ public class Settings
     /// <returns></returns>
     private string ComputeHashFromSeriesData()
     {
-        byte[] bytes = MD5.HashData(Encoding.UTF8.GetBytes(string.Join("", ListOfSeriesNumbers.OrderBy(x => x))));
+        List<int> copyOfSeriesNumbers = ListOfSeriesNumbers;
+        copyOfSeriesNumbers.RemoveAll(ListOfNumbersToExclude.Contains);
+
+        byte[] bytes = MD5.HashData(Encoding.UTF8.GetBytes(string.Join("", copyOfSeriesNumbers.OrderBy(x => x))));
 
         StringBuilder builder = new();
 


### PR DESCRIPTION
- The hash value created to name the directory was including numbers in the ExcludeTheseNumbers property and should not be. 
- Fix this to remove them from the list before hashing