### PR TITLE
add yml files to enforce branch name formats

### DIFF
--- a/.github/workflows/branch-name-check-oncreate.yml
+++ b/.github/workflows/branch-name-check-oncreate.yml
@@ -1,0 +1,15 @@
+name: Branch Name Check - Creation
+
+on:
+  create:
+
+jobs:
+  check-branch-name:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check Branch Name Format
+      run: |
+        if [[ ! "${{ github.ref }}" =~ ^refs/heads/(feature|bugfix)/[0-9]+-.* ]]; then
+          echo "Error: Branch name does not follow the 'feature/0000-feature-name' or 'bugfix/0000-bugfix-name' format (where 0000 is the Issue Id). Pull requests will be prevented."
+          exit 1
+        fi

--- a/.github/workflows/branch-name-check-pullrequest.yml
+++ b/.github/workflows/branch-name-check-pullrequest.yml
@@ -1,0 +1,15 @@
+name: Branch Name Check - Pull Request
+
+on: [pull_request]
+
+jobs:
+  check-branch-name:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Branch Name Format
+        run: |
+          branch_name=${GITHUB_HEAD_REF}
+          if [[ ! "$branch_name" =~ ^(feature|bugfix)/[0-9]+-.* ]]; then
+            echo "Error: Branch name '$branch_name' does not follow the 'feature/0000-feature-name' or 'bugfix/0000-bugfix-name' format (where 0000 is the Issue Id)."
+            exit 1
+          fi


### PR DESCRIPTION
- Add workflow rules to only allow PRs to be merged in that follow the naming format 'feature/issueId-feature-name' or 'bugfix/issueId-bugfix-name'
- Also throw an error for badly named branches on creation, however this does not prevent the push.