### PR TITLE
add SupportDimensions property to IGraphService

### DIFF
--- a/ThreeXPlusOne/Code/Graph/DirectedGraph.cs
+++ b/ThreeXPlusOne/Code/Graph/DirectedGraph.cs
@@ -97,6 +97,11 @@ public abstract class DirectedGraph(IOptions<Settings> settings,
                                                   .Where(graphService => graphService.GraphProvider == _settings.GraphProvider)
                                                   .First();
 
+        if (!graphService.SupportedDimensions.Contains(_settings.SanitizedGraphDimensions))
+        {
+            throw new Exception($"Graph provider {_settings.GraphProvider} does not support graphs in {_settings.SanitizedGraphDimensions} dimensions.");
+        }
+
         graphService.InitializeGraph([.. _nodes.Values],
                                      _canvasWidth,
                                      _canvasHeight);

--- a/ThreeXPlusOne/Code/Graph/Services/SkiaSharpGraphService.cs
+++ b/ThreeXPlusOne/Code/Graph/Services/SkiaSharpGraphService.cs
@@ -1,4 +1,5 @@
 using SkiaSharp;
+using System.Collections.ObjectModel;
 using System.Drawing;
 using ThreeXPlusOne.Code.Interfaces;
 using ThreeXPlusOne.Models;
@@ -14,6 +15,8 @@ public class SkiaSharpGraphService(IFileHelper fileHelper,
     private readonly Random _random = new();
 
     public GraphProvider GraphProvider => GraphProvider.SkiaSharp;
+
+    public ReadOnlyCollection<int> SupportedDimensions => new(new List<int> { 2, 3 });
 
     /// <summary>
     /// Initialize an SKSurface and SKCanvas based on the provided dimensions

--- a/ThreeXPlusOne/Code/Interfaces/IGraphService.cs
+++ b/ThreeXPlusOne/Code/Interfaces/IGraphService.cs
@@ -1,3 +1,4 @@
+using System.Collections.ObjectModel;
 using ThreeXPlusOne.Code.Graph.Services;
 using ThreeXPlusOne.Models;
 
@@ -9,6 +10,11 @@ public interface IGraphService
     /// The graph provider implementing the interface
     /// </summary>
     GraphProvider GraphProvider { get; }
+
+    /// <summary>
+    /// The dimensions the given graph service implementation supports in the context of rendering the graph
+    /// </summary>
+    ReadOnlyCollection<int> SupportedDimensions { get; }
 
     /// <summary>
     /// Initialize the graph based on the provided dimensions


### PR DESCRIPTION
- Add a ReadOnlyCollection<int> property to IGraphService to expose what dimensions the graph service allows graphs to be rendered in (could be 2, 3, or both)