### PR TITLE
RotateNode() accepts rotationAngle

### DIFF
--- a/ThreeXPlusOne.UnitTests/DirectedGraphTests.cs
+++ b/ThreeXPlusOne.UnitTests/DirectedGraphTests.cs
@@ -57,14 +57,13 @@ public class DirectedGraphTests
                                      float expectedYPrime)
     {
         // Arrange
-        _settings.Value.NodeRotationAngle = rotationAngle;
 
         MockDirectedGraph mockDirectedGraph = new(_settings,
                                                   _graphServicesList,
                                                   _consoleHelperMock.Object);
 
         // Act
-        (float xPrime, float yPrime) = mockDirectedGraph.RotateNode_Base(nodeValue, xCoordinate, yCoordinate);
+        (float xPrime, float yPrime) = mockDirectedGraph.RotateNode_Base(nodeValue, rotationAngle, xCoordinate, yCoordinate);
 
         // Assert
         xPrime.Should().Be(expectedXPrime);

--- a/ThreeXPlusOne.UnitTests/Mocks/MockDirectedGraph.cs
+++ b/ThreeXPlusOne.UnitTests/Mocks/MockDirectedGraph.cs
@@ -23,8 +23,8 @@ public class MockDirectedGraph(IOptions<Settings> settings,
     {
     }
 
-    public (float x, float y) RotateNode_Base(int nodeValue, float x, float y)
+    public (float x, float y) RotateNode_Base(int nodeValue, float rotationAngle, float x, float y)
     {
-        return RotateNode(nodeValue, x, y);
+        return RotateNode(nodeValue, rotationAngle, x, y);
     }
 }

--- a/ThreeXPlusOne/Code/Graph/DirectedGraph.cs
+++ b/ThreeXPlusOne/Code/Graph/DirectedGraph.cs
@@ -239,12 +239,14 @@ public abstract class DirectedGraph(IOptions<Settings> settings,
     /// If even, rotate clockwise. If odd, rotate anti-clockwise. But if the coordinates are in negative space, reverse this.
     /// </summary>
     /// <param name="nodeValue"></param>
+    /// <param name="rotationAngle"></param>
     /// <param name="x"></param>
     /// <param name="y"></param>
     /// <returns></returns>
-    protected (float X, float Y) RotateNode(int nodeValue,
-                                            float x,
-                                            float y)
+    protected static (float X, float Y) RotateNode(int nodeValue,
+                                                   float rotationAngle,
+                                                   float x,
+                                                   float y)
     {
         (float x, float y) rotatedPosition;
 
@@ -253,11 +255,11 @@ public abstract class DirectedGraph(IOptions<Settings> settings,
 
         if ((nodeValue % 2 == 0 && !isInNegativeSpace) || (nodeValue % 2 != 0 && isInNegativeSpace))
         {
-            rotatedPosition = RotatePointClockwise(x, y, _settings.NodeRotationAngle);
+            rotatedPosition = RotatePointClockwise(x, y, rotationAngle);
         }
         else
         {
-            rotatedPosition = RotatePointAntiClockwise(x, y, _settings.NodeRotationAngle);
+            rotatedPosition = RotatePointAntiClockwise(x, y, rotationAngle);
         }
 
         return rotatedPosition;
@@ -272,7 +274,7 @@ public abstract class DirectedGraph(IOptions<Settings> settings,
     /// <returns></returns>
     private static (float x, float y) RotatePointClockwise(float x,
                                                            float y,
-                                                           double angleDegrees)
+                                                           float angleDegrees)
     {
         double angleRadians = angleDegrees * Math.PI / 180.0; // Convert angle to radians
 
@@ -294,7 +296,7 @@ public abstract class DirectedGraph(IOptions<Settings> settings,
     /// <returns></returns>
     private static (float x, float y) RotatePointAntiClockwise(float x,
                                                                float y,
-                                                               double angleDegrees)
+                                                               float angleDegrees)
     {
         double angleRadians = angleDegrees * Math.PI / 180.0; // Convert angle to radians
 

--- a/ThreeXPlusOne/Code/Graph/ThreeDimensionalDirectedGraph.cs
+++ b/ThreeXPlusOne/Code/Graph/ThreeDimensionalDirectedGraph.cs
@@ -152,7 +152,7 @@ public class ThreeDimensionalDirectedGraph(IOptions<Settings> settings,
 
         if (_settings.NodeRotationAngle != 0)
         {
-            (float x, float y) = RotateNode(node.Value, xOffset, yOffset);
+            (float x, float y) = RotateNode(node.Value, _settings.NodeRotationAngle, xOffset, yOffset);
 
             node.Position = (x, y);
         }

--- a/ThreeXPlusOne/Code/Graph/TwoDimensionalDirectedGraph.cs
+++ b/ThreeXPlusOne/Code/Graph/TwoDimensionalDirectedGraph.cs
@@ -119,7 +119,7 @@ public class TwoDimensionalDirectedGraph(IOptions<Settings> settings,
 
             if (_settings.NodeRotationAngle != 0)
             {
-                (float x, float y) = RotateNode(node.Value, xOffset, yOffset);
+                (float x, float y) = RotateNode(node.Value, _settings.NodeRotationAngle, xOffset, yOffset);
 
                 node.Position = (x, y);
             }

--- a/ThreeXPlusOne/Config/Settings.cs
+++ b/ThreeXPlusOne/Config/Settings.cs
@@ -49,7 +49,7 @@ public class Settings
     /// <remarks>
     /// If the node value is even, it is rotated clockwise. If odd, anti-clockwise
     /// </remarks>
-    public double NodeRotationAngle { get; set; } = 0;
+    public float NodeRotationAngle { get; set; } = 0;
 
     /// <summary>
     /// The radius of the node


### PR DESCRIPTION
- Make RotateNode() accept a rotationAngle parameter for clarity. Refactor accordingly
- Changes Settings.NodeRotationAngle to be a float rather than a double