### PR TITLE
refactor IGraphService to use IDisposable

### DIFF
--- a/ThreeXPlusOne/Code/Graph/DirectedGraph.cs
+++ b/ThreeXPlusOne/Code/Graph/DirectedGraph.cs
@@ -101,9 +101,9 @@ public abstract class DirectedGraph(IOptions<Settings> settings,
             throw new Exception($"Graph provider {_settings.GraphProvider} does not support graphs in {_settings.SanitizedGraphDimensions} dimensions.");
         }
 
-        graphService.InitializeGraph([.. _nodes.Values],
-                                     _canvasWidth,
-                                     _canvasHeight);
+        graphService.Initialize([.. _nodes.Values],
+                                _canvasWidth,
+                                _canvasHeight);
 
         if (_settings.GenerateBackgroundStars)
         {
@@ -114,9 +114,9 @@ public abstract class DirectedGraph(IOptions<Settings> settings,
                           distortNodes: _settings.DistortNodes,
                           drawConnections: _settings.DrawConnections);
 
-        _consoleHelper.WriteDone();
-
-        graphService.SaveGraphImage();
+        graphService.Render();
+        graphService.SaveImage();
+        graphService.Dispose();
     }
 
     /// <summary>

--- a/ThreeXPlusOne/Code/Helpers/ConsoleHelper.cs
+++ b/ThreeXPlusOne/Code/Helpers/ConsoleHelper.cs
@@ -448,8 +448,8 @@ public class ConsoleHelper(IOptions<Settings> settings) : IConsoleHelper
 
     public void WriteSpinner(CancellationToken token)
     {
-        var spinner = new string[] { "|", "/", "-", "\\" };
         int counter = 0;
+        string[] spinner = ["|", "/", "-", "\\"];
 
         SetCursorVisibility(false);
 
@@ -464,7 +464,6 @@ public class ConsoleHelper(IOptions<Settings> settings) : IConsoleHelper
             Thread.Sleep(85);
         }
 
-        WriteDone();
         SetCursorVisibility(true);
     }
 
@@ -476,7 +475,7 @@ public class ConsoleHelper(IOptions<Settings> settings) : IConsoleHelper
         }
 
         string[] numbers = input.Split(',');
-        var truncated = new StringBuilder();
+        StringBuilder truncated = new();
         string ellipsis = $" ...see {_settings.SettingsFileName} for full value";
 
         int lengthWithEllipsis = maxLength - ellipsis.Length;

--- a/ThreeXPlusOne/Code/Interfaces/IGraphService.cs
+++ b/ThreeXPlusOne/Code/Interfaces/IGraphService.cs
@@ -4,7 +4,7 @@ using ThreeXPlusOne.Models;
 
 namespace ThreeXPlusOne.Code.Interfaces;
 
-public interface IGraphService
+public interface IGraphService : IDisposable
 {
     /// <summary>
     /// The graph provider implementing the interface
@@ -22,7 +22,7 @@ public interface IGraphService
     /// <param name="nodes"></param>
     /// <param name="width"></param>
     /// <param name="height"></param>
-    void InitializeGraph(List<DirectedGraphNode> nodes, int width, int height);
+    void Initialize(List<DirectedGraphNode> nodes, int width, int height);
 
     /// <summary>
     /// Draw the graph based on provided settings
@@ -39,8 +39,13 @@ public interface IGraphService
     void GenerateBackgroundStars(int starCount);
 
     /// <summary>
+    /// Render the graph
+    /// </summary>
+    void Render();
+
+    /// <summary>
     /// Save the generated graph as a png
     /// </summary>
     /// <exception cref="Exception"></exception>
-    void SaveGraphImage();
+    void SaveImage();
 }


### PR DESCRIPTION
- Make IGraphService implement IDisposable in order to be able to separate the rendering step from the image file saving step