### PR TITLE
add help text and a unit test

### DIFF
--- a/ThreeXPlusOne.UnitTests/Mocks/MockDirectedGraph.cs
+++ b/ThreeXPlusOne.UnitTests/Mocks/MockDirectedGraph.cs
@@ -23,8 +23,19 @@ public class MockDirectedGraph(IOptions<Settings> settings,
     {
     }
 
+    //ignore warning because this is called from a unit test instance
+#pragma warning disable CA1822 // Mark members as static
+
     public (float x, float y) RotateNode_Base(int nodeValue, float rotationAngle, float x, float y)
+
     {
         return RotateNode(nodeValue, rotationAngle, x, y);
+    }
+
+#pragma warning restore CA1822 // Mark members as static
+
+    public void DrawDirectedGraph_Base()
+    {
+        DrawDirectedGraph();
     }
 }

--- a/ThreeXPlusOne/Code/Helpers/ConsoleHelper.cs
+++ b/ThreeXPlusOne/Code/Helpers/ConsoleHelper.cs
@@ -255,6 +255,11 @@ public class ConsoleHelper(IOptions<Settings> settings) : IConsoleHelper
         WriteLine("true (whether or not to generate a file with metadata about the run)");
 
         SetForegroundColor(ConsoleColor.Blue);
+        Write($"    {nameof(Settings.GenerateLightSource)}: ");
+        SetForegroundColor(ConsoleColor.White);
+        WriteLine("true (whether or not to generate a light source from the top left of the graph that interacts with nodes)");
+
+        SetForegroundColor(ConsoleColor.Blue);
         Write($"    {nameof(Settings.GenerateBackgroundStars)}: ");
         SetForegroundColor(ConsoleColor.White);
         WriteLine("false (whether or not to generate random stars in the background of the graph)");
@@ -262,7 +267,7 @@ public class ConsoleHelper(IOptions<Settings> settings) : IConsoleHelper
         SetForegroundColor(ConsoleColor.Blue);
         Write($"    {nameof(Settings.OutputPath)}: ");
         SetForegroundColor(ConsoleColor.White);
-        WriteLine("\"C:\\path\\to\\save\\image\\\" (the folder where the output files should be placed)\n");
+        WriteLine("\"C:\\path\\to\\save\\image\\\" (the folder in which the output files should be placed)\n");
 
         WriteLine("Note: Increasing some settings may result in large canvas sizes, which could cause the program to fail. It depends on the capabilities of the machine running it.\n\n");
     }


### PR DESCRIPTION
- Add missing help text for new GenerateLightSource setting
- Add a unit test to ensure all expected IGraphService methods are called form DirectedGraph.DrawDirectedGraph(), crucially Dispose()