### PR TITLE
use Random.Shared instead of instances

### DIFF
--- a/ThreeXPlusOne/Code/Graph/DirectedGraph-NodeAesthetics.cs
+++ b/ThreeXPlusOne/Code/Graph/DirectedGraph-NodeAesthetics.cs
@@ -16,11 +16,9 @@ public abstract partial class DirectedGraph
         /// Assign a ShapeType to the node and vertices if applicable
         /// </summary>
         /// <param name="node"></param>
-        /// <param name="random"></param>
         /// <param name="nodeRadius"></param>
         /// <param name="includePolygonsAsNodes"></param>
         public void SetNodeShape(DirectedGraphNode node,
-                                 Random random,
                                  double nodeRadius,
                                  bool includePolygonsAsNodes)
         {
@@ -29,7 +27,7 @@ public abstract partial class DirectedGraph
                 node.Shape.Radius = nodeRadius;
             }
 
-            int numberOfSides = random.Next(0, 11);
+            int numberOfSides = Random.Shared.Next(0, 11);
 
             if (!includePolygonsAsNodes || numberOfSides == 0)
             {
@@ -40,12 +38,12 @@ public abstract partial class DirectedGraph
 
             if (numberOfSides == 1 || numberOfSides == 2)
             {
-                numberOfSides = random.Next(3, 11); //cannot have 1 or 2 sides, so re-select
+                numberOfSides = Random.Shared.Next(3, 11); //cannot have 1 or 2 sides, so re-select
             }
 
             node.Shape.ShapeType = ShapeType.Polygon;
 
-            double rotationAngle = random.NextDouble() * 2 * Math.PI;
+            double rotationAngle = Random.Shared.NextDouble() * 2 * Math.PI;
 
             for (int i = 0; i < numberOfSides; i++)
             {
@@ -90,18 +88,17 @@ public abstract partial class DirectedGraph
         /// <summary>
         /// Generate a random colour for the node
         /// </summary>
-        /// <param name="random"></param>
         /// <returns></returns>
-        public Color GenerateNodeColor(Random random)
+        public Color GenerateNodeColor()
         {
             byte red, green, blue;
-            byte alpha = (byte)random.Next(30, 231); //avoid too transparent, and avoid fully opaque
+            byte alpha = (byte)Random.Shared.Next(30, 231); //avoid too transparent, and avoid fully opaque
 
             do
             {
-                red = (byte)random.Next(256);
-                green = (byte)random.Next(256);
-                blue = (byte)random.Next(256);
+                red = (byte)Random.Shared.Next(256);
+                green = (byte)Random.Shared.Next(256);
+                blue = (byte)Random.Shared.Next(256);
             }
             while (red == 0 && green == 0 && blue == 0);    //avoid black
 

--- a/ThreeXPlusOne/Code/Graph/DirectedGraph.cs
+++ b/ThreeXPlusOne/Code/Graph/DirectedGraph.cs
@@ -15,7 +15,6 @@ public abstract partial class DirectedGraph(IOptions<Settings> settings,
     private int _canvasWidth = 0;
     private int _canvasHeight = 0;
 
-    protected readonly Random _random = new();
     protected readonly Settings _settings = settings.Value;
     protected readonly IConsoleHelper _consoleHelper = consoleHelper;
     protected readonly NodeAesthetics _nodeAesthetics = new();
@@ -140,7 +139,7 @@ public abstract partial class DirectedGraph(IOptions<Settings> settings,
 
         foreach (DirectedGraphNode node in _nodes.Values)
         {
-            Color nodeColor = _nodeAesthetics.GenerateNodeColor(_random);
+            Color nodeColor = _nodeAesthetics.GenerateNodeColor();
 
             if (lightSourceService.LightSourcePosition == LightSourcePosition.None)
             {

--- a/ThreeXPlusOne/Code/Graph/TwoDimensionalDirectedGraph.cs
+++ b/ThreeXPlusOne/Code/Graph/TwoDimensionalDirectedGraph.cs
@@ -77,7 +77,6 @@ public class TwoDimensionalDirectedGraph(IOptions<Settings> settings,
         foreach (DirectedGraphNode node in _nodes.Values.Where(node => node.IsPositioned))
         {
             _nodeAesthetics.SetNodeShape(node,
-                                         _random,
                                          _settings.NodeRadius,
                                          _settings.IncludePolygonsAsNodes);
         }

--- a/ThreeXPlusOne/Code/Interfaces/INodeAesthetics.cs
+++ b/ThreeXPlusOne/Code/Interfaces/INodeAesthetics.cs
@@ -9,11 +9,9 @@ public interface INodeAesthetics
     /// Assign a ShapeType to the node and vertices if applicable
     /// </summary>
     /// <param name="node"></param>
-    /// <param name="random"></param>
     /// <param name="nodeRadius"></param>
     /// <param name="includePolygonsAsNodes"></param>
     void SetNodeShape(DirectedGraphNode node,
-                      Random random,
                       double nodeRadius,
                       bool includePolygonsAsNodes);
 
@@ -34,9 +32,8 @@ public interface INodeAesthetics
     /// <summary>
     /// Generate a random colour for the node
     /// </summary>
-    /// <param name="random"></param>
     /// <returns></returns>
-    Color GenerateNodeColor(Random random);
+    Color GenerateNodeColor();
 
     /// <summary>
     /// If a light source is in place, it should impact the colour of nodes.

--- a/ThreeXPlusOne/Code/Process.cs
+++ b/ThreeXPlusOne/Code/Process.cs
@@ -106,7 +106,6 @@ public class Process(IOptions<Settings> settings,
     {
         consoleHelper.WriteHeading("Series data");
 
-        Random random = new();
         List<int> inputValues = [];
 
         if (string.IsNullOrWhiteSpace(_settings.UseTheseNumbers))
@@ -127,7 +126,7 @@ public class Process(IOptions<Settings> settings,
                     break;
                 }
 
-                int randomValue = random.Next(0, _settings.MaxStartingNumber) + 1;
+                int randomValue = Random.Shared.Next(0, _settings.MaxStartingNumber) + 1;
 
                 if (_settings.ListOfNumbersToExclude.Contains(randomValue))
                 {

--- a/ThreeXPlusOne/Code/Services/SkiaSharp/SkiaSharpDirectedGraphService.cs
+++ b/ThreeXPlusOne/Code/Services/SkiaSharp/SkiaSharpDirectedGraphService.cs
@@ -13,7 +13,6 @@ public class SkiaSharpDirectedGraphService(IFileHelper fileHelper) : IDirectedGr
     private SKSurface? _surface;
     private SKCanvas? _canvas;
     private SKImage? _image;
-    private readonly Random _random = new();
 
     public Action<string>? OnStart { get; set; }
     public Action? OnComplete { get; set; }
@@ -63,8 +62,8 @@ public class SkiaSharpDirectedGraphService(IFileHelper fileHelper) : IDirectedGr
 
         for (int i = 0; i < starCount; i++)
         {
-            double x = _random.NextDouble() * _canvas.LocalClipBounds.Width;
-            double y = _random.NextDouble() * _canvas.LocalClipBounds.Height;
+            double x = Random.Shared.NextDouble() * _canvas.LocalClipBounds.Width;
+            double y = Random.Shared.NextDouble() * _canvas.LocalClipBounds.Height;
 
             points.Add(ConvertCoordinatesToSKPoint(x, y));
         }
@@ -365,7 +364,7 @@ public class SkiaSharpDirectedGraphService(IFileHelper fileHelper) : IDirectedGr
     private void DrawStarWithBlur(SKCanvas canvas,
                                   SKPoint point)
     {
-        float starSize = _random.Next(10, 26); //from 10 to 26
+        float starSize = Random.Shared.Next(10, 26); //from 10 to 26
         float blurRadius = 9.0f;
 
         SKPaint blurPaint = new()


### PR DESCRIPTION
- Use Random.Shared instead of instances to avoid creating many new instances and to avoid having to create a Singleton instance
- Minor code cleanup