### PR TITLE
show error and usage info when an invalid command is entered

### DIFF
--- a/ThreeXPlusOne/App/Interfaces/Services/IConsoleService.cs
+++ b/ThreeXPlusOne/App/Interfaces/Services/IConsoleService.cs
@@ -86,6 +86,12 @@ public interface IConsoleService
     void WriteHelpText(List<(string longName, string shortName, string description, string hint)> commandLineOptions);
 
     /// <summary>
+    /// Output the command help
+    /// </summary>
+    /// <param name="commandLineOptions"></param>
+    void WriteCommandUsage(List<(string longName, string shortName, string description, string hint)> commandLineOptions);
+
+    /// <summary>
     /// Output the configuration info for the app
     /// </summary>
     void WriteConfigText();

--- a/ThreeXPlusOne/App/Services/ConsoleService.cs
+++ b/ThreeXPlusOne/App/Services/ConsoleService.cs
@@ -206,12 +206,28 @@ public class ConsoleService(IOptions<Settings> settings) : IConsoleService
 
     public void WriteHelpText(List<(string longName, string shortName, string description, string hint)> commandLineOptions)
     {
-        string? assemblyName = _assembly.GetName().Name;
-
         WriteAsciiArtLogo();
         WriteHeading("Help");
 
         WriteHeading("Commands");
+
+        WriteCommandUsage(commandLineOptions);
+
+        WriteHeading("Version");
+        WriteVersionText();
+
+        WriteHeading("GitHub repository");
+        WriteLine("https://github.com/wdthem/ThreeXPlusOne\n");
+
+        WriteHeading("Credits");
+        WriteLine("Inspiration from Veritasium: https://www.youtube.com/watch?v=094y1Z2wpJg");
+        WriteLine("ASCII art via: https://www.patorjk.com/software/taag/#p=display");
+        WriteLine("Graphs drawn with SkiaSharp: https://github.com/mono/SkiaSharp\n\n");
+    }
+
+    public void WriteCommandUsage(List<(string longName, string shortName, string description, string hint)> commandLineOptions)
+    {
+        string? assemblyName = _assembly.GetName().Name;
 
         Write($"usage: {assemblyName} ");
 
@@ -250,17 +266,6 @@ public class ConsoleService(IOptions<Settings> settings) : IConsoleService
         }
 
         WriteLine("");
-
-        WriteHeading("Version");
-        WriteVersionText();
-
-        WriteHeading("GitHub repository");
-        WriteLine("https://github.com/wdthem/ThreeXPlusOne\n");
-
-        WriteHeading("Credits");
-        WriteLine("Inspiration from Veritasium: https://www.youtube.com/watch?v=094y1Z2wpJg");
-        WriteLine("ASCII art via: https://www.patorjk.com/software/taag/#p=display");
-        WriteLine("Graphs drawn with SkiaSharp: https://github.com/mono/SkiaSharp\n\n");
     }
 
     public void WriteConfigText()

--- a/ThreeXPlusOne/CommandLine/CommandLineParser.cs
+++ b/ThreeXPlusOne/CommandLine/CommandLineParser.cs
@@ -145,7 +145,10 @@ public static class CommandLineParser
                       {
                           string tokenText = error is UnknownOptionError optionError ? $" (-{optionError.Token})" : "";
 
-                          errorText = $"Unknown command option ignored{tokenText}.";
+                          errorText = $"Unknown command option{tokenText}.";
+
+                          commandExecutionSettings.OptionsMetadata = GetOptionsAttributeMetadata();
+                          commandExecutionSettings.ContinueExecution = false;
                       }
                       else
                       {
@@ -159,8 +162,6 @@ public static class CommandLineParser
 
                       commandExecutionSettings.CommandParsingMessages.Add(errorText);
                   }
-
-                  commandExecutionSettings.ContinueExecution = true;
               });
 
         return commandExecutionSettings;

--- a/ThreeXPlusOne/CommandLine/CommandLineRunner.cs
+++ b/ThreeXPlusOne/CommandLine/CommandLineRunner.cs
@@ -28,6 +28,12 @@ public class CommandLineRunner(IProcess process,
     /// <param name="commandExecutionSettings"></param>
     private void HandleOptions(CommandExecutionSettings commandExecutionSettings)
     {
+        if (commandExecutionSettings.CommandParsingMessages.Count > 0 && !commandExecutionSettings.ContinueExecution)
+        {
+            consoleService.WriteError(string.Join(", ", commandExecutionSettings.CommandParsingMessages));
+            consoleService.WriteCommandUsage(commandExecutionSettings.OptionsMetadata);
+        }
+
         if (commandExecutionSettings.WriteHelpText)
         {
             consoleService.WriteHelpText(commandExecutionSettings.OptionsMetadata);

--- a/ThreeXPlusOne/ThreeXPlusOne.csproj
+++ b/ThreeXPlusOne/ThreeXPlusOne.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>1.2.5</Version>
+    <Version>1.2.6</Version>
     <AssemblyVersion>$(Version)</AssemblyVersion>
     <FileVersion>$(Version)</FileVersion>
     <AssemblyInformationalVersion>$(Version)</AssemblyInformationalVersion>
-    <TagMessage>Move Config folder to App folder</TagMessage>
+    <TagMessage>Handle unknown command line parameters</TagMessage>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
- Instead of ignoring and continuing, show an error message + usage info when an unknown/invalid command line parameter is entered.