### PR TITLE
more efficient ShapeFactory

### DIFF
--- a/ThreeXPlusOne.UnitTests/DirectedGraphTests.cs
+++ b/ThreeXPlusOne.UnitTests/DirectedGraphTests.cs
@@ -6,11 +6,12 @@ using System.Drawing;
 using ThreeXPlusOne.App.Config;
 using ThreeXPlusOne.App.Enums;
 using ThreeXPlusOne.App.DirectedGraph;
+using ThreeXPlusOne.App.Interfaces.DirectedGraph;
 using ThreeXPlusOne.App.Interfaces.Services;
 using ThreeXPlusOne.App.Models;
 using ThreeXPlusOne.UnitTests.Mocks;
 using Xunit;
-using ThreeXPlusOne.App.Interfaces;
+
 
 namespace ThreeXPlusOne.UnitTests;
 

--- a/ThreeXPlusOne/App/DirectedGraph/DirectedGraph-NodeAesthetics.cs
+++ b/ThreeXPlusOne/App/DirectedGraph/DirectedGraph-NodeAesthetics.cs
@@ -1,7 +1,7 @@
 using System.Drawing;
 using System.Text.RegularExpressions;
 using ThreeXPlusOne.App.Enums;
-using ThreeXPlusOne.App.Interfaces;
+using ThreeXPlusOne.App.Interfaces.DirectedGraph;
 using ThreeXPlusOne.App.Models;
 
 namespace ThreeXPlusOne.App.DirectedGraph;

--- a/ThreeXPlusOne/App/DirectedGraph/DirectedGraph.cs
+++ b/ThreeXPlusOne/App/DirectedGraph/DirectedGraph.cs
@@ -2,7 +2,7 @@
 using System.Drawing;
 using ThreeXPlusOne.App.Config;
 using ThreeXPlusOne.App.Enums;
-using ThreeXPlusOne.App.Interfaces;
+using ThreeXPlusOne.App.Interfaces.DirectedGraph;
 using ThreeXPlusOne.App.Interfaces.Services;
 using ThreeXPlusOne.App.Models;
 

--- a/ThreeXPlusOne/App/DirectedGraph/Shapes/Arc.cs
+++ b/ThreeXPlusOne/App/DirectedGraph/Shapes/Arc.cs
@@ -1,5 +1,5 @@
 using ThreeXPlusOne.App.Enums;
-using ThreeXPlusOne.App.Interfaces;
+using ThreeXPlusOne.App.Interfaces.DirectedGraph;
 
 namespace ThreeXPlusOne.App.DirectedGraph.Shapes;
 

--- a/ThreeXPlusOne/App/DirectedGraph/Shapes/Ellipse.cs
+++ b/ThreeXPlusOne/App/DirectedGraph/Shapes/Ellipse.cs
@@ -1,5 +1,5 @@
 using ThreeXPlusOne.App.Enums;
-using ThreeXPlusOne.App.Interfaces;
+using ThreeXPlusOne.App.Interfaces.DirectedGraph;
 
 namespace ThreeXPlusOne.App.DirectedGraph.Shapes;
 

--- a/ThreeXPlusOne/App/DirectedGraph/Shapes/Pill.cs
+++ b/ThreeXPlusOne/App/DirectedGraph/Shapes/Pill.cs
@@ -1,5 +1,5 @@
 using ThreeXPlusOne.App.Enums;
-using ThreeXPlusOne.App.Interfaces;
+using ThreeXPlusOne.App.Interfaces.DirectedGraph;
 
 namespace ThreeXPlusOne.App.DirectedGraph.Shapes;
 

--- a/ThreeXPlusOne/App/DirectedGraph/Shapes/Polygon.cs
+++ b/ThreeXPlusOne/App/DirectedGraph/Shapes/Polygon.cs
@@ -1,5 +1,5 @@
 using ThreeXPlusOne.App.Enums;
-using ThreeXPlusOne.App.Interfaces;
+using ThreeXPlusOne.App.Interfaces.DirectedGraph;
 
 namespace ThreeXPlusOne.App.DirectedGraph.Shapes;
 

--- a/ThreeXPlusOne/App/DirectedGraph/Shapes/SemiCircle.cs
+++ b/ThreeXPlusOne/App/DirectedGraph/Shapes/SemiCircle.cs
@@ -1,5 +1,5 @@
 using ThreeXPlusOne.App.Enums;
-using ThreeXPlusOne.App.Interfaces;
+using ThreeXPlusOne.App.Interfaces.DirectedGraph;
 
 namespace ThreeXPlusOne.App.DirectedGraph.Shapes;
 

--- a/ThreeXPlusOne/App/DirectedGraph/Shapes/ShapeFactory.cs
+++ b/ThreeXPlusOne/App/DirectedGraph/Shapes/ShapeFactory.cs
@@ -1,12 +1,11 @@
-using ThreeXPlusOne.App.DirectedGraph.Shapes;
 using ThreeXPlusOne.App.Enums;
-using ThreeXPlusOne.App.Interfaces;
+using ThreeXPlusOne.App.Interfaces.DirectedGraph;
 
-namespace ThreeXPlusOne.App.Factories;
+namespace ThreeXPlusOne.App.DirectedGraph.Shapes;
 
-public class ShapeFactory(IEnumerable<IShape> shapes) : IShapeFactory
+public class ShapeFactory() : IShapeFactory
 {
-    private readonly List<IShape> _shapesList = shapes.ToList();
+    private readonly ShapeType[] _shapeTypes = (ShapeType[])Enum.GetValues(typeof(ShapeType));
 
     /// <summary>
     /// Create either the ShapeType specified or a randomly-selected ShapeType
@@ -15,7 +14,7 @@ public class ShapeFactory(IEnumerable<IShape> shapes) : IShapeFactory
     /// <returns></returns>
     public IShape CreateShape(ShapeType? shapeType = null)
     {
-        shapeType ??= _shapesList[Random.Shared.Next(0, _shapesList.Count)].ShapeType;
+        shapeType ??= _shapeTypes[Random.Shared.Next(_shapeTypes.Length)];
 
         return shapeType switch
         {

--- a/ThreeXPlusOne/App/Interfaces/DirectedGraph/IShape.cs
+++ b/ThreeXPlusOne/App/Interfaces/DirectedGraph/IShape.cs
@@ -2,7 +2,7 @@ using System.Drawing;
 using ThreeXPlusOne.App.Enums;
 using ThreeXPlusOne.App.Models;
 
-namespace ThreeXPlusOne.App.Interfaces;
+namespace ThreeXPlusOne.App.Interfaces.DirectedGraph;
 
 public interface IShape
 {

--- a/ThreeXPlusOne/App/Interfaces/DirectedGraph/IShapeFactory.cs
+++ b/ThreeXPlusOne/App/Interfaces/DirectedGraph/IShapeFactory.cs
@@ -1,6 +1,6 @@
 using ThreeXPlusOne.App.Enums;
 
-namespace ThreeXPlusOne.App.Interfaces;
+namespace ThreeXPlusOne.App.Interfaces.DirectedGraph;
 
 public interface IShapeFactory
 {

--- a/ThreeXPlusOne/App/Models/DirectedGraphNode.cs
+++ b/ThreeXPlusOne/App/Models/DirectedGraphNode.cs
@@ -1,5 +1,5 @@
 ﻿using ThreeXPlusOne.App.DirectedGraph.Shapes;
-using ThreeXPlusOne.App.Interfaces;
+using ThreeXPlusOne.App.Interfaces.DirectedGraph;
 
 namespace ThreeXPlusOne.App.Models;
 

--- a/ThreeXPlusOne/StartupExtensions.cs
+++ b/ThreeXPlusOne/StartupExtensions.cs
@@ -11,7 +11,6 @@ using ThreeXPlusOne.App.Services.SkiaSharp;
 using ThreeXPlusOne.App.Interfaces;
 using ThreeXPlusOne.App.Config;
 using ThreeXPlusOne.CommandLine.Models;
-using ThreeXPlusOne.App.Factories;
 using ThreeXPlusOne.App.DirectedGraph.Shapes;
 
 namespace ThreeXPlusOne;
@@ -79,15 +78,7 @@ public static class StartupExtensions
         services.AddScoped<IDirectedGraph, ThreeDimensionalDirectedGraph>();
         services.AddScoped<IDirectedGraphService, SkiaSharpDirectedGraphService>();
 
-        services.AddScoped<IShapeFactory, ShapeFactory>();
-
-        //These are injected into the ShapeFactory for read-only purposes, so can be a singleton
-        services.AddSingleton<IShape, Ellipse>();
-        services.AddSingleton<IShape, Polygon>();
-        services.AddSingleton<IShape, SemiCircle>();
-        services.AddSingleton<IShape, Arc>();
-        services.AddSingleton<IShape, Pill>();
-
+        services.AddSingleton<IShapeFactory, ShapeFactory>();
         services.AddSingleton<IConsoleService, ConsoleService>();
 
         return services;

--- a/ThreeXPlusOne/ThreeXPlusOne.csproj
+++ b/ThreeXPlusOne/ThreeXPlusOne.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>1.5.1</Version>
+    <Version>1.5.2</Version>
     <AssemblyVersion>$(Version)</AssemblyVersion>
     <FileVersion>$(Version)</FileVersion>
     <AssemblyInformationalVersion>$(Version)</AssemblyInformationalVersion>
-    <TagMessage>Move arc settings to configuration class</TagMessage>
+    <TagMessage>More efficient ShapeFactory</TagMessage>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
- Instead of injecting a list of IShape and not actually using the instances, just select random shapes from the list of ShapeType enums
- Move some interfaces to more appropriate folders