### PR TITLE
weighted shape selection + fix 4-sided shape dimensions

### DIFF
--- a/ThreeXPlusOne.UnitTests/DirectedGraphTests.cs
+++ b/ThreeXPlusOne.UnitTests/DirectedGraphTests.cs
@@ -11,6 +11,7 @@ using ThreeXPlusOne.App.Interfaces.Services;
 using ThreeXPlusOne.App.Models;
 using ThreeXPlusOne.UnitTests.Mocks;
 using Xunit;
+using ThreeXPlusOne.App.Interfaces.DirectedGraph;
 
 namespace ThreeXPlusOne.UnitTests;
 
@@ -32,7 +33,7 @@ public class DirectedGraphTests
         _lightSourceServiceMock = new Mock<ILightSourceService>();
         _graphServiceMock = new Mock<IDirectedGraphService>();
         _graphServicesList = [_graphServiceMock.Object];
-        _shapeFactory = new ShapeFactory();
+        _shapeFactory = new ShapeFactory([]);
     }
 
     [Fact]

--- a/ThreeXPlusOne/App/DirectedGraph/Shapes/Arc.cs
+++ b/ThreeXPlusOne/App/DirectedGraph/Shapes/Arc.cs
@@ -8,6 +8,8 @@ public class Arc() : Shape, IShape
 {
     public ShapeType ShapeType => ShapeType.Arc;
 
+    public int SelectionWeight => 1;
+
     /// <summary>
     /// Set the configuration details for the shape used to represent the graph node
     /// </summary>

--- a/ThreeXPlusOne/App/DirectedGraph/Shapes/Ellipse.cs
+++ b/ThreeXPlusOne/App/DirectedGraph/Shapes/Ellipse.cs
@@ -11,6 +11,8 @@ public class Ellipse() : Shape, IShape
 {
     public ShapeType ShapeType => ShapeType.Ellipse;
 
+    public int SelectionWeight => 1;
+
     /// <summary>
     /// Stretch the ellipse radii for skewed shapes
     /// </summary>

--- a/ThreeXPlusOne/App/DirectedGraph/Shapes/Pill.cs
+++ b/ThreeXPlusOne/App/DirectedGraph/Shapes/Pill.cs
@@ -8,6 +8,8 @@ public class Pill() : Shape, IShape
 {
     public ShapeType ShapeType => ShapeType.Pill;
 
+    public int SelectionWeight => 1;
+
     /// <summary>
     /// Set the configuration details for the shape used to represent the graph node
     /// </summary>

--- a/ThreeXPlusOne/App/DirectedGraph/Shapes/Polygon.cs
+++ b/ThreeXPlusOne/App/DirectedGraph/Shapes/Polygon.cs
@@ -7,6 +7,38 @@ public class Polygon() : Shape, IShape
 {
     public ShapeType ShapeType => ShapeType.Polygon;
 
+    //This class can generate 10 different polygons, thus the weighting of 10 to 
+    //put each polygon type on equal footing to all other distinct shapes
+    public int SelectionWeight => 10;
+
+    /// <summary>
+    /// Get a randomly-selected number of sides from 3 to 8 (min: triangle, max: octagon)
+    /// </summary>
+    /// <remarks>
+    /// More weight is applied toward selecting a four-sided shape given there are multiple 4-sided shapes
+    /// </remarks>
+    /// <returns></returns>
+    private static int GenerateNumberOfSides()
+    {
+        int[] weights = [1, 5, 1, 1, 1, 1];  // Weights for numbers 3, 4, 5, 6, 7, 8
+
+        int[] cumulativeWeights = new int[weights.Length];
+        int totalWeight = 0;
+
+        for (int i = 0; i < weights.Length; i++)
+        {
+            totalWeight += weights[i];
+            cumulativeWeights[i] = totalWeight;
+        }
+
+        int randomNumber = Random.Shared.Next(1, totalWeight + 1);
+
+        int numberOfSides = Enumerable.Range(0, cumulativeWeights.Length)
+                                      .FirstOrDefault(i => randomNumber <= cumulativeWeights[i]) + 3; // Add 3 to the index to get the correct number in the range
+
+        return numberOfSides;
+    }
+
     /// <summary>
     /// Rotate the points so the shape is not always drawn in the same orientation
     /// </summary>
@@ -64,8 +96,8 @@ public class Polygon() : Shape, IShape
     {
         _shapeConfiguration.PolygonConfiguration = new();
 
-        double width = nodeRadius;
-        double height = width / 2;
+        double width = nodeRadius * 2;
+        double height = nodeRadius;
 
         _shapeConfiguration.PolygonConfiguration.Vertices.Add(RotateVertex((nodePosition.X - width / 2, nodePosition.Y - height / 2), nodePosition, rotationAngle));
         _shapeConfiguration.PolygonConfiguration.Vertices.Add(RotateVertex((nodePosition.X + width / 2, nodePosition.Y - height / 2), nodePosition, rotationAngle));
@@ -85,13 +117,13 @@ public class Polygon() : Shape, IShape
     {
         _shapeConfiguration.PolygonConfiguration = new();
 
-        double angleRadians = Math.PI * 60 / 180;
-        double halfDiagonal = nodeRadius * Math.Cos(angleRadians / 2);
+        double horizontalDistance = nodeRadius * 1.5 * Math.Cos(Math.PI / 6); // 30 degrees
+        double verticalDistance = nodeRadius * 1.5 * Math.Sin(Math.PI / 6); // 30 degrees
 
-        _shapeConfiguration.PolygonConfiguration.Vertices.Add(RotateVertex((nodePosition.X, nodePosition.Y - halfDiagonal), nodePosition, rotationAngle));
-        _shapeConfiguration.PolygonConfiguration.Vertices.Add(RotateVertex((nodePosition.X + halfDiagonal, nodePosition.Y), nodePosition, rotationAngle));
-        _shapeConfiguration.PolygonConfiguration.Vertices.Add(RotateVertex((nodePosition.X, nodePosition.Y + halfDiagonal), nodePosition, rotationAngle));
-        _shapeConfiguration.PolygonConfiguration.Vertices.Add(RotateVertex((nodePosition.X - halfDiagonal, nodePosition.Y), nodePosition, rotationAngle));
+        _shapeConfiguration.PolygonConfiguration.Vertices.Add(RotateVertex((nodePosition.X, nodePosition.Y - verticalDistance), nodePosition, rotationAngle));
+        _shapeConfiguration.PolygonConfiguration.Vertices.Add(RotateVertex((nodePosition.X + horizontalDistance, nodePosition.Y), nodePosition, rotationAngle));
+        _shapeConfiguration.PolygonConfiguration.Vertices.Add(RotateVertex((nodePosition.X, nodePosition.Y + verticalDistance), nodePosition, rotationAngle));
+        _shapeConfiguration.PolygonConfiguration.Vertices.Add(RotateVertex((nodePosition.X - horizontalDistance, nodePosition.Y), nodePosition, rotationAngle));
     }
 
     /// <summary>
@@ -101,13 +133,13 @@ public class Polygon() : Shape, IShape
     /// <param name="nodeRadius"></param>
     /// <param name="rotationAngle"></param>
     private void ConfigureParallelogram((double X, double Y) nodePosition,
-                                   double nodeRadius,
-                                   double rotationAngle)
+                                        double nodeRadius,
+                                        double rotationAngle)
     {
         _shapeConfiguration.PolygonConfiguration = new();
 
-        double baseLength = nodeRadius / 2;
-        double sideLength = nodeRadius;
+        double baseLength = nodeRadius * 2;
+        double sideLength = nodeRadius * 1.75;
         double angleRadians = Math.PI * 30 / 180;
         double height = sideLength * Math.Sin(angleRadians);
 
@@ -129,11 +161,11 @@ public class Polygon() : Shape, IShape
     {
         _shapeConfiguration.PolygonConfiguration = new();
 
-        double topWidth = nodeRadius * 0.667;
-        double height = nodeRadius / 2;
+        double topWidth = nodeRadius * 2 * 0.667;
+        double height = nodeRadius * 1.4;
 
         double halfTopWidth = topWidth / 2;
-        double halfBottomWidth = nodeRadius / 2;
+        double halfBottomWidth = topWidth;
 
         _shapeConfiguration.PolygonConfiguration.Vertices.Add(RotateVertex((nodePosition.X - halfTopWidth, nodePosition.Y), nodePosition, rotationAngle));
         _shapeConfiguration.PolygonConfiguration.Vertices.Add(RotateVertex((nodePosition.X + halfTopWidth, nodePosition.Y), nodePosition, rotationAngle));
@@ -149,7 +181,7 @@ public class Polygon() : Shape, IShape
     public void SetShapeConfiguration((double X, double Y) nodePosition,
                                       double nodeRadius)
     {
-        int numberOfSides = Random.Shared.Next(3, 9); //min: triangle, max: octagon
+        int numberOfSides = GenerateNumberOfSides();
         double rotationAngle = Random.Shared.NextDouble() * 2 * Math.PI;
 
         if (numberOfSides != 4)

--- a/ThreeXPlusOne/App/DirectedGraph/Shapes/Seashell.cs
+++ b/ThreeXPlusOne/App/DirectedGraph/Shapes/Seashell.cs
@@ -10,6 +10,8 @@ public class Seashell() : Shape, IShape
 
     public ShapeType ShapeType => ShapeType.Seashell;
 
+    public int SelectionWeight => 1;
+
     /// <summary>
     /// Set the configuration details for the shape used to represent the graph node
     /// </summary>

--- a/ThreeXPlusOne/App/DirectedGraph/Shapes/SemiCircle.cs
+++ b/ThreeXPlusOne/App/DirectedGraph/Shapes/SemiCircle.cs
@@ -8,6 +8,8 @@ public class SemiCircle() : Shape, IShape
 {
     public ShapeType ShapeType => ShapeType.SemiCircle;
 
+    public int SelectionWeight => 1;
+
     /// <summary>
     /// Set the configuration details for the shape used to represent the graph node
     /// </summary>

--- a/ThreeXPlusOne/App/DirectedGraph/Shapes/ShapeFactory.cs
+++ b/ThreeXPlusOne/App/DirectedGraph/Shapes/ShapeFactory.cs
@@ -3,9 +3,63 @@ using ThreeXPlusOne.App.Interfaces.DirectedGraph;
 
 namespace ThreeXPlusOne.App.DirectedGraph.Shapes;
 
-public class ShapeFactory()
+public class ShapeFactory(IEnumerable<IShape> shapes)
 {
-    private readonly ShapeType[] _shapeTypes = (ShapeType[])Enum.GetValues(typeof(ShapeType));
+    private List<KeyValuePair<ShapeType, ShapeSelectionWeight>>? _shapeSelectionWeights;
+    private int _totalWeight = 0;
+
+    /// <summary>
+    /// Prepare the data required for weighting the selection of shapes
+    /// </summary>
+    /// <returns></returns>
+    private List<KeyValuePair<ShapeType, ShapeSelectionWeight>> ConfigureShapeSelectionWeights()
+    {
+        List<KeyValuePair<ShapeType, ShapeSelectionWeight>> shapeWeightsList =
+            shapes.Select(shape => new KeyValuePair<ShapeType, ShapeSelectionWeight>
+                                        (
+                                            shape.ShapeType,
+                                            new ShapeSelectionWeight() { Weight = shape.SelectionWeight }
+                                        ))
+                  .ToList();
+
+        int totalWeight = 0;
+
+        foreach (KeyValuePair<ShapeType, ShapeSelectionWeight> pair in shapeWeightsList)
+        {
+            totalWeight += pair.Value.Weight;
+            pair.Value.CumulativeWeight = totalWeight;
+        }
+
+        return shapeWeightsList;
+    }
+
+    /// <summary>
+    /// Return either the passed-in ShapeType or a randomly-selected shape, biased toward defined weightings
+    /// </summary>
+    /// <param name="shapeType"></param>
+    /// <returns></returns>
+    /// <exception cref="InvalidOperationException"></exception>
+    private ShapeType SelectShapeType(ShapeType? shapeType)
+    {
+        if (shapeType != null)
+        {
+            return shapeType.Value;
+        }
+
+        if (_shapeSelectionWeights == null)
+        {
+            _shapeSelectionWeights = ConfigureShapeSelectionWeights();
+            _totalWeight = _shapeSelectionWeights.Sum(pair => pair.Value.Weight);
+        }
+
+        int randomNumber = Random.Shared.Next(1, _totalWeight + 1);
+
+        ShapeType selectedShapeType =
+            _shapeSelectionWeights.FirstOrDefault(pair => randomNumber <= pair.Value.CumulativeWeight).Key;
+
+        return selectedShapeType;
+    }
+
 
     /// <summary>
     /// Create either the ShapeType specified or a randomly-selected ShapeType
@@ -14,7 +68,7 @@ public class ShapeFactory()
     /// <returns></returns>
     public IShape CreateShape(ShapeType? shapeType = null)
     {
-        shapeType ??= _shapeTypes[Random.Shared.Next(_shapeTypes.Length)];
+        shapeType = SelectShapeType(shapeType);
 
         return shapeType switch
         {
@@ -27,5 +81,21 @@ public class ShapeFactory()
             ShapeType.Seashell => new Seashell(),
             _ => throw new ArgumentException($"Unsupported ShapeType in ShapeFactory.CreateShape(): {shapeType}"),
         };
+    }
+
+    /// <summary>
+    /// Local model class for helping to weight the selection of shapes
+    /// </summary>
+    private class ShapeSelectionWeight
+    {
+        /// <summary>
+        /// The weight of the shape, as defined in the individual shape class
+        /// </summary>
+        public int Weight { get; set; }
+
+        /// <summary>
+        /// The running total of the given shape's weight plus all weights before it
+        /// </summary>
+        public int CumulativeWeight { get; set; }
     }
 }

--- a/ThreeXPlusOne/App/DirectedGraph/Shapes/Star.cs
+++ b/ThreeXPlusOne/App/DirectedGraph/Shapes/Star.cs
@@ -9,6 +9,8 @@ public class Star() : Shape, IShape
 
     public ShapeType ShapeType => ShapeType.Star;
 
+    public int SelectionWeight => 1;
+
     /// <summary>
     /// Set the configuration details for the shape used to represent the graph node
     /// </summary>

--- a/ThreeXPlusOne/App/Interfaces/DirectedGraph/IShape.cs
+++ b/ThreeXPlusOne/App/Interfaces/DirectedGraph/IShape.cs
@@ -27,6 +27,14 @@ public interface IShape
     double Radius { get; set; }
 
     /// <summary>
+    /// The weight assigned to the given shape with respect to it being randomly selected as the shape for the node
+    /// <remarks>
+    /// Used to bias the selection toward shapes with higher weights
+    /// </remarks>
+    /// </summary>
+    int SelectionWeight { get; }
+
+    /// <summary>
     /// Set the configuration of the given shape, optionally skewing it
     /// </summary>
     /// <param name="nodePosition"></param>

--- a/ThreeXPlusOne/StartupExtensions.cs
+++ b/ThreeXPlusOne/StartupExtensions.cs
@@ -78,6 +78,14 @@ public static class StartupExtensions
         services.AddScoped<IDirectedGraph, ThreeDimensionalDirectedGraph>();
         services.AddScoped<IDirectedGraphService, SkiaSharpDirectedGraphService>();
 
+        services.AddSingleton<IShape, Arc>();
+        services.AddSingleton<IShape, Ellipse>();
+        services.AddSingleton<IShape, Pill>();
+        services.AddSingleton<IShape, Polygon>();
+        services.AddSingleton<IShape, Seashell>();
+        services.AddSingleton<IShape, SemiCircle>();
+        services.AddSingleton<IShape, Star>();
+
         services.AddSingleton<ShapeFactory>();
         services.AddSingleton<IConsoleService, ConsoleService>();
 

--- a/ThreeXPlusOne/ThreeXPlusOne.csproj
+++ b/ThreeXPlusOne/ThreeXPlusOne.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>1.8.1</Version>
+    <Version>1.8.2</Version>
     <AssemblyVersion>$(Version)</AssemblyVersion>
     <FileVersion>$(Version)</FileVersion>
     <AssemblyInformationalVersion>$(Version)</AssemblyInformationalVersion>
-    <TagMessage>Move trapezoid code to Polygon class</TagMessage>
+    <TagMessage>Weighted random selection to account for more polygon shapes varieties</TagMessage>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
- Implement a weighting system for randomly selecting shapes given the Polygon class can generate 10 different shapes.
- Within polygon, also do weighting to bias toward 4-sided shapes as there are 5 possible 4-sided shapes

This puts all shapes on equal footing for selection.