### PR TITLE
fix casting issue with histogram scale factor

### DIFF
--- a/ThreeXPlusOne/App/Services/SkiaSharp/SkiaSharpHistogramService.cs
+++ b/ThreeXPlusOne/App/Services/SkiaSharp/SkiaSharpHistogramService.cs
@@ -58,7 +58,7 @@ public class SkiaSharpHistogramService() : IHistogramService
 
         // Scale the bars to leave space for the count text
         int adjustedMaxCount = maxCount + (maxCount / 10); // Adjust for space above the tallest bar
-        double scaleFactor = (effectiveCanvasHeight - xAxisLabelHeight - topPadding) / adjustedMaxCount;
+        double scaleFactor = (effectiveCanvasHeight - xAxisLabelHeight - topPadding) / (double)adjustedMaxCount;
 
         // Define maximum height and segment count
         const int maxSegmentCount = 10;

--- a/ThreeXPlusOne/ThreeXPlusOne.csproj
+++ b/ThreeXPlusOne/ThreeXPlusOne.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>1.12.4</Version>
+    <Version>1.12.5</Version>
     <AssemblyVersion>$(Version)</AssemblyVersion>
     <FileVersion>$(Version)</FileVersion>
     <AssemblyInformationalVersion>$(Version)</AssemblyInformationalVersion>
-    <TagMessage>Fixed skewed-shape lighting issues</TagMessage>
+    <TagMessage>Fixed histogram bug</TagMessage>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
The scale factor calculation was dividing by an integer and losing all decimal places. Fix by casting divisor to a double